### PR TITLE
Made __contains__ correctly handle keys like None, True, False and similar

### DIFF
--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -81,9 +81,15 @@ class Bunch(dict):
             >>> b.hello = 'hai'
             >>> 'hello' in b
             True
+            >>> b[None] = 123
+            >>> None in b
+            True
+            >>> b[False] = 456
+            >>> False in b
+            True
         """
         try:
-            return hasattr(self, k) or dict.__contains__(self, k)
+            return dict.__contains__(self, k) or hasattr(self, k)
         except:
             return False
     


### PR DESCRIPTION
Hi David,

can you please merge it in? It lets one use None, True and similar things as bunch keys which is what regular dictionaries allow one to do as well. Without the change the **contains** method incorrectly reports that such a key doesn't exist in a Bunch instance, like below.

Cheers!

> > > from bunch import Bunch
> > > b = Bunch({None:123})
> > > None in b
> > > False
> > > None in b.keys()
> > > True
> > > 
> > > d = {None:456}
> > > None in d
> > > True
> > > None in d.keys()
> > > True
