### PR TITLE
Fix python version check

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version_info >= (3,))
 
 identity = lambda x : x
 


### PR DESCRIPTION
The recent merge for python3 compatibility contained some code that wasn't correct.  Checking for the version of python that code is being run on should compare against sys.version_info.  The current code compares against platform.version which is something else entirely.

A side note to the fix -- Function calls are expensive in python.  If the places that python3_compat.u() are used turn out to be performance critical there might be noticable slowdowns.  python-3.3 re-adds the u"I am string" syntax so one idea could be to punt this issue and say that if run on python3, bunch needs python-3.3 or greater.
