### PR TITLE
Fix py25 or less compat

### DIFF
--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -28,7 +28,7 @@ VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = ('Bunch', 'bunchify','unbunchify',)
 
-from .python3_compat import *
+from bunch.python3_compat import u, iteritems, iterkeys
 
 class Bunch(dict):
     """ A dictionary that provides attribute-style access.


### PR DESCRIPTION
The recent commit to allow python3 support introduced a relative import syntax that is only available on python-2.6 or later.  This change request modifies the import so that it works on older python versions as well.
