### PR TITLE
Fix unspecified "except:" blocks

### DIFF
--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -89,10 +89,7 @@ class Bunch(dict):
             >>> False in b
             True
         """
-        try:
-            return dict.__contains__(self, k) or hasattr(self, k)
-        except:
-            return False
+        return dict.__contains__(self, k) or hasattr(self, k)
     
     # only called if k not found in normal places 
     def __getattr__(self, k):
@@ -149,7 +146,7 @@ class Bunch(dict):
         except AttributeError:
             try:
                 self[k] = v
-            except:
+            except KeyError:
                 raise AttributeError(k)
         else:
             object.__setattr__(self, k, v)


### PR DESCRIPTION
Those are bad since they catch every exception out there, including
KeyboardInterrupt and the like.

The first block is entirely removed as the two function call are not
supposed to raise anything given legit parameters.
The second should, according to the method description, only catch
KeyError to change them into AttributeError.
