### PR TITLE
Update python3_compat.py

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version_info >= (3, 0, 0))
 
 identity = lambda x : x
 


### PR DESCRIPTION
platform.version might work on some platforms, but does NOT always start with the python version number (On Ubuntu, at least, it doesn't even contain the version number!).
