### PR TITLE
Fixed Python 3 version check to return the correct result

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version_info[0] >= 3)
 
 identity = lambda x : x
 


### PR DESCRIPTION
The current Python 3 version check returns `True` in both Python 2.x and 3.x.

This commit fixes that to use `sys.version_info` which contains the Python version as a tuple.
