### PR TITLE
Check Python version rather than System version.

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
 import platform
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (platform.python_version() >= '3')
 
 identity = lambda x : x
 


### PR DESCRIPTION
The intent of the _IS_PYTHON_3 test appears to be to 
check the version of the Python interpreter not the version 
of the system.

If this is the case, then a call to platform.python_version() 
is required rather than platform.version(), as per the docs.

(platform.version() returns the system's release version, 
whereas platform.python_version returns the python version)

https://docs.python.org/2.6/library/platform.html?highlight=platform#platform.version
https://docs.python.org/2.7/library/platform.html?highlight=platform#platform.version
file:///usr/share/doc/python3-doc/html/library/platform.html?highlight=platform#platform.version