### PR TITLE
Fixed obtaining the python version

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version >= '3')
 
 identity = lambda x : x
 


### PR DESCRIPTION
The version of the Python distribution was wrongfully obtained from `platform.version()`, which provides the platform version. This was returning `True` almost always as platform versions are usually strings starting with a letter. Found it through an Ubuntu version starting with a `#`, which precedes digits in the encoding table. Replaced it with `sys.version`.
