### PR TITLE
fixed py3k bug

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
 import platform
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (platform.python_version() >= '3')
 
 identity = lambda x : x
 


### PR DESCRIPTION
Hi,

In Python 3.5.1:
Python 3.5.1 (default, May  9 2016, 14:04:33)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-16)] on linux
Type "help", "copyright", "credits" or "license" for more information.

> > > import platform
> > > (platform.version() >= '3')
> > > False
> > > platform.version()
> > > '#1 SMP Thu Mar 12 18:39:03 UTC 2015'
> > > platform.python_version()
> > > '3.5.1'

In Python 2.7.10:
Python 2.7.10 (default, Oct 23 2015, 19:19:21) 
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

> > > import platform
> > > platform.version() 
> > > 'Darwin Kernel Version 15.4.0: Fri Feb 26 22:08:05 PST 2016; root:xnu-3248.40.184~3/RELEASE_X86_64'
> > > platform.python_version()
> > > '2.7.10'
