### PR TITLE
Fix python interpreter version check

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version_info.major >= 3)
 
 identity = lambda x : x
 


### PR DESCRIPTION
The version check for python is broken. This pull request proposes a fix. I am pasting the output from python running on my macbook.

Abhinavs-MacBook-Pro: $ python
Python 2.7.10 (default, Jul 30 2016, 18:31:42)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.version()
'Darwin Kernel Version 16.0.0: Mon Aug 29 17:56:20 PDT 2016; root:xnu-3789.1.32~3/RELEASE_X86_64'
>>> platform.version() >= '3'
True
>>> import sys
>>> sys.version_info.major
2
>>> sys.version_info.major >= 3
False