### PR TITLE
Fix in operator wrong behavior

### DIFF
--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -185,8 +185,8 @@ class Bunch(dict):
         """ Recursively converts a bunch back into a dictionary.
             
             >>> b = Bunch(foo=Bunch(lol=True), hello=42, ponies='are pretty!')
-            >>> b.toDict()
-            {'ponies': 'are pretty!', 'foo': {'lol': True}, 'hello': 42}
+            >>> b.toDict() == {'ponies': 'are pretty!', 'foo': {'lol': True}, 'hello': 42}
+            True
             
             See unbunchify for more info.
         """
@@ -259,18 +259,18 @@ def unbunchify(x):
     """ Recursively converts a Bunch into a dictionary.
         
         >>> b = Bunch(foo=Bunch(lol=True), hello=42, ponies='are pretty!')
-        >>> unbunchify(b)
-        {'ponies': 'are pretty!', 'foo': {'lol': True}, 'hello': 42}
-        
+        >>> unbunchify(b) == {'ponies': 'are pretty!', 'foo': {'lol': True}, 'hello': 42}
+        True
+    
         unbunchify will handle intermediary dicts, lists and tuples (as well as
         their subclasses), but ymmv on custom datatypes.
         
         >>> b = Bunch(foo=['bar', Bunch(lol=True)], hello=42, 
         ...         ponies=('are pretty!', Bunch(lies='are trouble!')))
-        >>> unbunchify(b) #doctest: +NORMALIZE_WHITESPACE
-        {'ponies': ('are pretty!', {'lies': 'are trouble!'}), 
-         'foo': ['bar', {'lol': True}], 'hello': 42}
-        
+        >>> unbunchify(b) == {'ponies': ('are pretty!', {'lies': 'are trouble!'}),
+        ...         'foo': ['bar', {'lol': True}], 'hello': 42}
+        True
+
         nb. As dicts are not hashable, they cannot be nested in sets/frozensets.
     """
     if isinstance(x, dict):

--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -160,10 +160,10 @@ class Bunch(dict):
             propagate as an AttributeError instead.
             
             >>> b = Bunch(lol=42)
-            >>> del b.values
+            >>> del b.values  # doctest: +ELLIPSIS
             Traceback (most recent call last):
                 ...
-            AttributeError: 'Bunch' object attribute 'values' is read-only
+            AttributeError: ...values...
             >>> del b.lol
             >>> b.lol
             Traceback (most recent call last):

--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -88,11 +88,17 @@ class Bunch(dict):
             >>> b[False] = 456
             >>> False in b
             True
+            >>> 'items' in b, 'keys' in b, 'values' in b
+            (False, False, False)
+            >>> b['values']
+            Traceback (most recent call last):
+              File "<doctest bunch.Bunch.__contains__[12]>", line 1, in <module>
+                b['values']
+            KeyError: 'values'
+            >>> b.values  # doctest: +ELLIPSIS
+            <built-in method values of Bunch object at ...>
         """
-        try:
-            return dict.__contains__(self, k) or hasattr(self, k)
-        except:
-            return False
+        return dict.__contains__(self, k)
     
     # only called if k not found in normal places 
     def __getattr__(self, k):

--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -70,36 +70,6 @@ class Bunch(dict):
         See unbunchify/Bunch.toDict, bunchify/Bunch.fromDict for notes about conversion.
     """
     
-    def __contains__(self, k):
-        """ >>> b = Bunch(ponies='are pretty!')
-            >>> 'ponies' in b
-            True
-            >>> 'foo' in b
-            False
-            >>> b['foo'] = 42
-            >>> 'foo' in b
-            True
-            >>> b.hello = 'hai'
-            >>> 'hello' in b
-            True
-            >>> b[None] = 123
-            >>> None in b
-            True
-            >>> b[False] = 456
-            >>> False in b
-            True
-            >>> 'items' in b, 'keys' in b, 'values' in b
-            (False, False, False)
-            >>> b['values']
-            Traceback (most recent call last):
-              File "<doctest bunch.Bunch.__contains__[12]>", line 1, in <module>
-                b['values']
-            KeyError: 'values'
-            >>> b.values  # doctest: +ELLIPSIS
-            <built-in method values of Bunch object at ...>
-        """
-        return dict.__contains__(self, k)
-    
     # only called if k not found in normal places 
     def __getattr__(self, k):
         """ Gets key if it exists, otherwise throws AttributeError.

--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -120,7 +120,7 @@ class Bunch(dict):
         """
         try:
             # Throws exception if not in prototype chain
-            return object.__getattribute__(self, k)
+            return dict.__getattribute__(self, k)
         except AttributeError:
             try:
                 return self[k]
@@ -145,14 +145,14 @@ class Bunch(dict):
         """
         try:
             # Throws exception if not in prototype chain
-            object.__getattribute__(self, k)
+            dict.__getattribute__(self, k)
         except AttributeError:
             try:
                 self[k] = v
             except:
                 raise AttributeError(k)
         else:
-            object.__setattr__(self, k, v)
+            dict.__setattr__(self, k, v)
     
     def __delattr__(self, k):
         """ Deletes attribute k if it exists, otherwise deletes key k. A KeyError
@@ -172,14 +172,14 @@ class Bunch(dict):
         """
         try:
             # Throws exception if not in prototype chain
-            object.__getattribute__(self, k)
+            dict.__getattribute__(self, k)
         except AttributeError:
             try:
                 del self[k]
             except KeyError:
                 raise AttributeError(k)
         else:
-            object.__delattr__(self, k)
+            dict.__delattr__(self, k)
     
     def toDict(self):
         """ Recursively converts a bunch back into a dictionary.

--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -119,13 +119,9 @@ class Bunch(dict):
             True
         """
         try:
-            # Throws exception if not in prototype chain
-            return object.__getattribute__(self, k)
-        except AttributeError:
-            try:
-                return self[k]
-            except KeyError:
-                raise AttributeError(k)
+           return self[k]
+        except KeyError:
+           raise AttributeError(k)
     
     def __setattr__(self, k, v):
         """ Sets attribute k if it exists, otherwise sets key k. A KeyError

--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version_info[0] >= 3)
 
 identity = lambda x : x
 


### PR DESCRIPTION
The __contains__ method is actually redundant and causes a strange behavior documented in the additional tests in this pull request.