### PR TITLE
remove redudant code from __getattr__

### DIFF
--- a/bunch/__init__.py
+++ b/bunch/__init__.py
@@ -119,13 +119,9 @@ class Bunch(dict):
             True
         """
         try:
-            # Throws exception if not in prototype chain
-            return object.__getattribute__(self, k)
-        except AttributeError:
-            try:
-                return self[k]
-            except KeyError:
-                raise AttributeError(k)
+           return self[k]
+        except KeyError:
+           raise AttributeError(k)
     
     def __setattr__(self, k, v):
         """ Sets attribute k if it exists, otherwise sets key k. A KeyError


### PR DESCRIPTION
The method __getattr__ is called as a fallback method for __getattribute__ hence the removed call always fails and is unnecessary.