### PR TITLE
Fix wrong python version detection

### DIFF
--- a/bunch/python3_compat.py
+++ b/bunch/python3_compat.py
@@ -1,6 +1,6 @@
-import platform
+import sys
 
-_IS_PYTHON_3 = (platform.version() >= '3')
+_IS_PYTHON_3 = (sys.version_info[0] >= 3)
 
 identity = lambda x : x
 


### PR DESCRIPTION
platform.version() doesn't return the python version. 
platform.python_version() or platform.python_version_tuple() would also work but sys.version_info is more popular.