### PR TITLE
Change setup.py filemode from 'rU' to simply 'r' for New Python Versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 HERE = abspath(dirname(__file__))
 readme = open(join(HERE, 'README.rst')).read()
 
-package_file = open(join(HERE, 'bunch/__init__.py'), 'rU')
+package_file = open(join(HERE, 'bunch/__init__.py'), 'ru')
 __version__ = re.sub(
     r".*\b__version__\s+=\s+'([^']+)'.*",
     r'\1',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 HERE = abspath(dirname(__file__))
 readme = open(join(HERE, 'README.rst')).read()
 
-package_file = open(join(HERE, 'bunch/__init__.py'), 'ru')
+package_file = open(join(HERE, 'bunch/__init__.py'), 'r')
 __version__ = re.sub(
     r".*\b__version__\s+=\s+'([^']+)'.*",
     r'\1',


### PR DESCRIPTION
Python version 3.10 breaks bunch installation as 'rU' is no longer supported for filemode in setup.py: 'U' or universal newlines is deprecated.
This is a quick fix that simply removes the U flag and enables the package to be installed successfully on new python versions.
